### PR TITLE
Fix Listcurrentpu modules commad in parser

### DIFF
--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -475,33 +475,22 @@ public class Parser {
         }
     }
 
-    private Command prepareListCurrentPUModulesCommand(String univAbbNameOrIndex, ArrayList<University> universities,
+    private Command prepareListCurrentPUModulesCommand(String univAbbName, ArrayList<University> universities,
                                                        ArrayList<Module> modules) {
-        char digitChecker = univAbbNameOrIndex.charAt(0);
-        String universityAbbName = "";
-        int univIndex = -1;
-        // remember handle exception for numberformatexception use stringtoint instead?
-        if (Character.isDigit(digitChecker)) {
-            univIndex = Integer.parseInt(univAbbNameOrIndex) - 1;
-        } else {
-            universityAbbName = univAbbNameOrIndex;
-        }
         try {
-            return handleListCurrentPuModulesCommand(universities, universityAbbName, univIndex, modules);
+            return handleListCurrentPuModulesCommand(universities, univAbbName, modules);
         } catch (InvalidPuException e) {
             return new ExceptionHandleCommand(e);
         }
     }
 
     private Command handleListCurrentPuModulesCommand(ArrayList<University> universities, String universityAbbName,
-                                                      int univIndex, ArrayList<Module> modules)
+                                                      ArrayList<Module> modules)
             throws InvalidPuException {
         int univID = 0;
-        if (univIndex == -1) {
-            for (University university : universities) {
-                if (universityAbbName.equalsIgnoreCase(university.getUnivAbbName())) {
-                    univID = university.getUnivId();
-                }
+        for (University university : universities) {
+            if (universityAbbName.equalsIgnoreCase(university.getUnivAbbName())) {
+                univID = university.getUnivId();
             }
         }
         if (univID == 0) {


### PR DESCRIPTION
Program crashes when user types in /list current 999999999999999999

Fix:
Change list current to only accept PU Abbrev, this also aligns with our user guide better. 